### PR TITLE
pointed hue.js dependency to bahamas10 forked fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "posix-getopt": "~1.0.0",
-    "hue.js": "~0.2.13",
+    "hue.js": "https://github.com/bahamas10/hue.js/tarball/dave-1432672068",
     "latest": "~0.1.1",
     "css-color-names": "0.0.0",
     "extsprintf": "~1.0.2"


### PR DESCRIPTION
I was unable to use your hue-cli bc the hue.js repo owner hasn't yet merged your pull request to fix the bug on node 0.12.x. I forked your repo and pointed the hue.js dependency to your forked fix. Then, I pushed this up to my fork. I then re-installed hue-cli by pointing it to my fork, like so: `sudo install -g https://github.com/YBerth13/hue-cli/tarball/master`, and it's working. I'm pretty new to git and github and programming in general, but I decided it made sense to submit a pull request, right?

If I'm not mistaken, if you were to accept this pull request, then when people run the standard `npm install -g hue-cli`, it should install the your forked, fixed version of hue.js, correct? I guess the best thing right now would be if that hue.js accepts your pull request soon.